### PR TITLE
feat/kinesisdataanalytics-checkpoints-alarms

### DIFF
--- a/API.md
+++ b/API.md
@@ -67567,13 +67567,13 @@ new KinesisDataAnalyticsMonitoring(scope: MonitoringScope, props: KinesisDataAna
 | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring.summaryWidgets">summaryWidgets</a></code> | Returns widgets to be placed on the summary dashboard. |
 | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring.widgets">widgets</a></code> | Returns widgets to be placed on the main dashboard. |
 | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring.widgetsForDashboard">widgetsForDashboard</a></code> | Returns widgets for the requested dashboard type. |
-| <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring.createCheckpointFailuresWidget">createCheckpointFailuresWidget</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring.createDownTimeWidget">createDownTimeWidget</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring.createFullRestartsWidget">createFullRestartsWidget</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring.createGarbageCollectionWidget">createGarbageCollectionWidget</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring.createKPUWidget">createKPUWidget</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring.createLastCheckpointDurationWidget">createLastCheckpointDurationWidget</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring.createLastCheckpointSizeWidget">createLastCheckpointSizeWidget</a></code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring.createNumberOfFailedCheckpointsWidget">createNumberOfFailedCheckpointsWidget</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring.createResourceUtilizationWidget">createResourceUtilizationWidget</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring.createTitleWidget">createTitleWidget</a></code> | *No description.* |
 
@@ -67674,24 +67674,6 @@ Returns widgets for the requested dashboard type.
 ###### `name`<sup>Required</sup> <a name="name" id="cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring.widgetsForDashboard.parameter.name"></a>
 
 - *Type:* string
-
----
-
-##### `createCheckpointFailuresWidget` <a name="createCheckpointFailuresWidget" id="cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring.createCheckpointFailuresWidget"></a>
-
-```typescript
-public createCheckpointFailuresWidget(width: number, height: number): GraphWidget
-```
-
-###### `width`<sup>Required</sup> <a name="width" id="cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring.createCheckpointFailuresWidget.parameter.width"></a>
-
-- *Type:* number
-
----
-
-###### `height`<sup>Required</sup> <a name="height" id="cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring.createCheckpointFailuresWidget.parameter.height"></a>
-
-- *Type:* number
 
 ---
 
@@ -67798,6 +67780,24 @@ public createLastCheckpointSizeWidget(width: number, height: number): GraphWidge
 ---
 
 ###### `height`<sup>Required</sup> <a name="height" id="cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring.createLastCheckpointSizeWidget.parameter.height"></a>
+
+- *Type:* number
+
+---
+
+##### `createNumberOfFailedCheckpointsWidget` <a name="createNumberOfFailedCheckpointsWidget" id="cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring.createNumberOfFailedCheckpointsWidget"></a>
+
+```typescript
+public createNumberOfFailedCheckpointsWidget(width: number, height: number): GraphWidget
+```
+
+###### `width`<sup>Required</sup> <a name="width" id="cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring.createNumberOfFailedCheckpointsWidget.parameter.width"></a>
+
+- *Type:* number
+
+---
+
+###### `height`<sup>Required</sup> <a name="height" id="cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring.createNumberOfFailedCheckpointsWidget.parameter.height"></a>
 
 - *Type:* number
 

--- a/API.md
+++ b/API.md
@@ -25733,6 +25733,7 @@ const kinesisDataAnalyticsMonitoringOptions: KinesisDataAnalyticsMonitoringOptio
 | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMonitoringOptions.property.addCheckpointFailureRateAlarm">addCheckpointFailureRateAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ErrorRateThreshold">ErrorRateThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMonitoringOptions.property.addDowntimeAlarm">addDowntimeAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.MaxDowntimeThreshold">MaxDowntimeThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMonitoringOptions.property.addFullRestartCountAlarm">addFullRestartCountAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.FullRestartCountThreshold">FullRestartCountThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMonitoringOptions.property.addFullRestartRateAlarm">addFullRestartRateAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ErrorRateThreshold">ErrorRateThreshold</a>}</code> | *No description.* |
 
 ---
 
@@ -25904,6 +25905,16 @@ public readonly addFullRestartCountAlarm: {[ key: string ]: FullRestartCountThre
 
 ---
 
+##### `addFullRestartRateAlarm`<sup>Optional</sup> <a name="addFullRestartRateAlarm" id="cdk-monitoring-constructs.KinesisDataAnalyticsMonitoringOptions.property.addFullRestartRateAlarm"></a>
+
+```typescript
+public readonly addFullRestartRateAlarm: {[ key: string ]: ErrorRateThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.ErrorRateThreshold">ErrorRateThreshold</a>}
+
+---
+
 ### KinesisDataAnalyticsMonitoringProps <a name="KinesisDataAnalyticsMonitoringProps" id="cdk-monitoring-constructs.KinesisDataAnalyticsMonitoringProps"></a>
 
 #### Initializer <a name="Initializer" id="cdk-monitoring-constructs.KinesisDataAnalyticsMonitoringProps.Initializer"></a>
@@ -25932,6 +25943,7 @@ const kinesisDataAnalyticsMonitoringProps: KinesisDataAnalyticsMonitoringProps =
 | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMonitoringProps.property.addCheckpointFailureRateAlarm">addCheckpointFailureRateAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ErrorRateThreshold">ErrorRateThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMonitoringProps.property.addDowntimeAlarm">addDowntimeAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.MaxDowntimeThreshold">MaxDowntimeThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMonitoringProps.property.addFullRestartCountAlarm">addFullRestartCountAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.FullRestartCountThreshold">FullRestartCountThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMonitoringProps.property.addFullRestartRateAlarm">addFullRestartRateAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ErrorRateThreshold">ErrorRateThreshold</a>}</code> | *No description.* |
 
 ---
 
@@ -26110,6 +26122,16 @@ public readonly addFullRestartCountAlarm: {[ key: string ]: FullRestartCountThre
 ```
 
 - *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.FullRestartCountThreshold">FullRestartCountThreshold</a>}
+
+---
+
+##### `addFullRestartRateAlarm`<sup>Optional</sup> <a name="addFullRestartRateAlarm" id="cdk-monitoring-constructs.KinesisDataAnalyticsMonitoringProps.property.addFullRestartRateAlarm"></a>
+
+```typescript
+public readonly addFullRestartRateAlarm: {[ key: string ]: ErrorRateThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.ErrorRateThreshold">ErrorRateThreshold</a>}
 
 ---
 
@@ -68287,6 +68309,7 @@ new KinesisDataAnalyticsAlarmFactory(alarmFactory: AlarmFactory)
 | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsAlarmFactory.addCheckpointFailureRateAlarm">addCheckpointFailureRateAlarm</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsAlarmFactory.addDowntimeAlarm">addDowntimeAlarm</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsAlarmFactory.addFullRestartAlarm">addFullRestartAlarm</a></code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsAlarmFactory.addFullRestartRateAlarm">addFullRestartRateAlarm</a></code> | *No description.* |
 
 ---
 
@@ -68386,6 +68409,30 @@ public addFullRestartAlarm(metric: Metric | MathExpression, props: FullRestartCo
 
 ---
 
+##### `addFullRestartRateAlarm` <a name="addFullRestartRateAlarm" id="cdk-monitoring-constructs.KinesisDataAnalyticsAlarmFactory.addFullRestartRateAlarm"></a>
+
+```typescript
+public addFullRestartRateAlarm(metric: Metric | MathExpression, props: ErrorRateThreshold, disambiguator?: string): AlarmWithAnnotation
+```
+
+###### `metric`<sup>Required</sup> <a name="metric" id="cdk-monitoring-constructs.KinesisDataAnalyticsAlarmFactory.addFullRestartRateAlarm.parameter.metric"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.Metric | aws-cdk-lib.aws_cloudwatch.MathExpression
+
+---
+
+###### `props`<sup>Required</sup> <a name="props" id="cdk-monitoring-constructs.KinesisDataAnalyticsAlarmFactory.addFullRestartRateAlarm.parameter.props"></a>
+
+- *Type:* <a href="#cdk-monitoring-constructs.ErrorRateThreshold">ErrorRateThreshold</a>
+
+---
+
+###### `disambiguator`<sup>Optional</sup> <a name="disambiguator" id="cdk-monitoring-constructs.KinesisDataAnalyticsAlarmFactory.addFullRestartRateAlarm.parameter.disambiguator"></a>
+
+- *Type:* string
+
+---
+
 
 
 
@@ -68427,6 +68474,7 @@ new KinesisDataAnalyticsMetricFactory(metricFactory: MetricFactory, props: Kines
 | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMetricFactory.metricCheckpointFailureRate">metricCheckpointFailureRate</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMetricFactory.metricCpuUtilizationPercent">metricCpuUtilizationPercent</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMetricFactory.metricDowntimeMs">metricDowntimeMs</a></code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMetricFactory.metricFullRestartRate">metricFullRestartRate</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMetricFactory.metricFullRestartsCount">metricFullRestartsCount</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMetricFactory.metricHeapMemoryUtilizationPercent">metricHeapMemoryUtilizationPercent</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMetricFactory.metricKPUsCount">metricKPUsCount</a></code> | *No description.* |
@@ -68455,6 +68503,12 @@ public metricCpuUtilizationPercent(): Metric | MathExpression
 
 ```typescript
 public metricDowntimeMs(): Metric | MathExpression
+```
+
+##### `metricFullRestartRate` <a name="metricFullRestartRate" id="cdk-monitoring-constructs.KinesisDataAnalyticsMetricFactory.metricFullRestartRate"></a>
+
+```typescript
+public metricFullRestartRate(): Metric | MathExpression
 ```
 
 ##### `metricFullRestartsCount` <a name="metricFullRestartsCount" id="cdk-monitoring-constructs.KinesisDataAnalyticsMetricFactory.metricFullRestartsCount"></a>
@@ -68828,6 +68882,8 @@ public createTitleWidget(): MonitoringHeaderWidget
 | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring.property.downtimeAnnotations">downtimeAnnotations</a></code> | <code>aws-cdk-lib.aws_cloudwatch.HorizontalAnnotation[]</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring.property.downtimeMsMetric">downtimeMsMetric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring.property.fullRestartAnnotations">fullRestartAnnotations</a></code> | <code>aws-cdk-lib.aws_cloudwatch.HorizontalAnnotation[]</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring.property.fullRestartRateAnnotations">fullRestartRateAnnotations</a></code> | <code>aws-cdk-lib.aws_cloudwatch.HorizontalAnnotation[]</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring.property.fullRestartRateMetric">fullRestartRateMetric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring.property.fullRestartsCountMetric">fullRestartsCountMetric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring.property.heapMemoryUtilizationPercentMetric">heapMemoryUtilizationPercentMetric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring.property.kdaAlarmFactory">kdaAlarmFactory</a></code> | <code><a href="#cdk-monitoring-constructs.KinesisDataAnalyticsAlarmFactory">KinesisDataAnalyticsAlarmFactory</a></code> | *No description.* |
@@ -68909,6 +68965,26 @@ public readonly fullRestartAnnotations: HorizontalAnnotation[];
 ```
 
 - *Type:* aws-cdk-lib.aws_cloudwatch.HorizontalAnnotation[]
+
+---
+
+##### `fullRestartRateAnnotations`<sup>Required</sup> <a name="fullRestartRateAnnotations" id="cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring.property.fullRestartRateAnnotations"></a>
+
+```typescript
+public readonly fullRestartRateAnnotations: HorizontalAnnotation[];
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.HorizontalAnnotation[]
+
+---
+
+##### `fullRestartRateMetric`<sup>Required</sup> <a name="fullRestartRateMetric" id="cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring.property.fullRestartRateMetric"></a>
+
+```typescript
+public readonly fullRestartRateMetric: Metric | MathExpression;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.Metric | aws-cdk-lib.aws_cloudwatch.MathExpression
 
 ---
 

--- a/lib/common/monitoring/alarms/KinesisDataAnalyticsAlarmFactory.ts
+++ b/lib/common/monitoring/alarms/KinesisDataAnalyticsAlarmFactory.ts
@@ -20,8 +20,6 @@ export interface FullRestartCountThreshold extends CustomAlarmThreshold {
   readonly maxFullRestartCount: number;
 }
 
-// Using standard ErrorCountThreshold and ErrorRateThreshold from ErrorAlarmFactory
-
 export class KinesisDataAnalyticsAlarmFactory {
   protected readonly alarmFactory: AlarmFactory;
   protected readonly errorAlarmFactory: ErrorAlarmFactory;

--- a/lib/common/monitoring/alarms/KinesisDataAnalyticsAlarmFactory.ts
+++ b/lib/common/monitoring/alarms/KinesisDataAnalyticsAlarmFactory.ts
@@ -70,6 +70,26 @@ export class KinesisDataAnalyticsAlarmFactory {
     });
   }
 
+  addFullRestartRateAlarm(
+    metric: MetricWithAlarmSupport,
+    props: ErrorRateThreshold,
+    disambiguator?: string,
+  ) {
+    return this.alarmFactory.addAlarm(metric, {
+      treatMissingData:
+        props.treatMissingDataOverride ?? TreatMissingData.BREACHING,
+      comparisonOperator:
+        props.comparisonOperatorOverride ??
+        ComparisonOperator.GREATER_THAN_THRESHOLD,
+      ...props,
+      disambiguator,
+      threshold: props.maxErrorRate,
+      alarmNameSuffix: "FullRestartRate",
+      alarmDescription: "Full restart rate is too high",
+      alarmDedupeStringSuffix: "KDAFullRestartRateAlarm",
+    });
+  }
+
   addCheckpointFailureCountAlarm(
     metric: MetricWithAlarmSupport,
     props: ErrorCountThreshold,

--- a/lib/monitoring/aws-kinesisanalytics/KinesisDataAnalyticsMetricFactory.ts
+++ b/lib/monitoring/aws-kinesisanalytics/KinesisDataAnalyticsMetricFactory.ts
@@ -5,7 +5,6 @@ import {
   BaseMetricFactoryProps,
   MetricFactory,
   MetricStatistic,
-  RateComputationMethod,
 } from "../../common";
 
 export interface KinesisDataAnalyticsMetricFactoryProps
@@ -120,11 +119,34 @@ export class KinesisDataAnalyticsMetricFactory extends BaseMetricFactory<Kinesis
   }
 
   metricCheckpointFailureRate() {
-    return this.metricFactory.toRate(
-      this.metricNumberOfFailedCheckpointsCount(),
-      RateComputationMethod.PER_HOUR,
-      false,
-      "checkpoints",
+    // Flink reports this metric as the latest sum for the lifecycle of a job.
+    // Therefore, we truly care about rate of change
+    return this.metricFactory.createMetricMath(
+      "RATE(numberOfFailedCheckpoints)",
+      {
+        numberOfFailedCheckpoints: this.metricNumberOfFailedCheckpointsCount(),
+      },
+      "Checkpoint Failure Rate",
+      undefined,
+      undefined,
+      this.region,
+      this.account,
+    );
+  }
+
+  metricFullRestartRate() {
+    // Flink reports this metric as the latest sum for the lifecycle of a job.
+    // Therefore, we truly care about rate of change
+    return this.metricFactory.createMetricMath(
+      "RATE(fullRestarts)",
+      {
+        fullRestarts: this.metricFullRestartsCount(),
+      },
+      "Full Restart Rate",
+      undefined,
+      undefined,
+      this.region,
+      this.account,
     );
   }
 

--- a/lib/monitoring/aws-kinesisanalytics/KinesisDataAnalyticsMonitoring.ts
+++ b/lib/monitoring/aws-kinesisanalytics/KinesisDataAnalyticsMonitoring.ts
@@ -233,7 +233,7 @@ export class KinesisDataAnalyticsMonitoring extends Monitoring {
     });
   }
 
-  createCheckpointFailuresWidget(width: number, height: number) {
+  createNumberOfFailedCheckpointsWidget(width: number, height: number) {
     return new GraphWidget({
       width,
       height,
@@ -295,7 +295,7 @@ export class KinesisDataAnalyticsMonitoring extends Monitoring {
   private createCheckpointAndGcWidgets(): GraphWidget[] {
     return [
       // Checkpointing
-      this.createCheckpointFailuresWidget(
+      this.createNumberOfFailedCheckpointsWidget(
         QuarterWidth,
         DefaultGraphWidgetHeight,
       ),

--- a/test/facade/__snapshots__/MonitoringAspect.test.ts.snap
+++ b/test/facade/__snapshots__/MonitoringAspect.test.ts.snap
@@ -4798,11 +4798,11 @@ Object {
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"AWS/KinesisAnalytics\\",\\"fullRestarts\\",{\\"label\\":\\"Restarts\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Checkpoint Failures\\",\\"region\\":\\"",
+              "\\",\\"metrics\\":[[\\"AWS/KinesisAnalytics\\",\\"fullRestarts\\",{\\"label\\":\\"Restarts\\",\\"id\\":\\"fullRestarts\\"}],[{\\"label\\":\\"Full Restart Rate\\",\\"expression\\":\\"RATE(fullRestarts)\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false},\\"right\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Checkpoint Failures\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"AWS/KinesisAnalytics\\",\\"numberOfFailedCheckpoints\\",{\\"label\\":\\"Failed Checkpoints\\",\\"stat\\":\\"Sum\\",\\"id\\":\\"checkpoints\\"}],[{\\"label\\":\\"Failed Checkpoints/h\\",\\"expression\\":\\"(3600 * checkpoints) / PERIOD(checkpoints)\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false},\\"right\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Checkpoint Duration\\",\\"region\\":\\"",
+              "\\",\\"metrics\\":[[\\"AWS/KinesisAnalytics\\",\\"numberOfFailedCheckpoints\\",{\\"label\\":\\"Failed Checkpoints\\",\\"stat\\":\\"Sum\\",\\"id\\":\\"numberOfFailedCheckpoints\\"}],[{\\"label\\":\\"Checkpoint Failure Rate\\",\\"expression\\":\\"RATE(numberOfFailedCheckpoints)\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false},\\"right\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Checkpoint Duration\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -4852,7 +4852,7 @@ Object {
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"AWS/KinesisAnalytics\\",\\"fullRestarts\\",{\\"label\\":\\"Restarts\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}}]}",
+              "\\",\\"metrics\\":[[\\"AWS/KinesisAnalytics\\",\\"fullRestarts\\",{\\"label\\":\\"Restarts\\",\\"id\\":\\"fullRestarts\\"}],[{\\"label\\":\\"Full Restart Rate\\",\\"expression\\":\\"RATE(fullRestarts)\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false},\\"right\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}}]}",
             ],
           ],
         },

--- a/test/monitoring/aws-kinesisanalytics/KinesisDataAnalyticsMonitoring.test.ts
+++ b/test/monitoring/aws-kinesisanalytics/KinesisDataAnalyticsMonitoring.test.ts
@@ -18,6 +18,24 @@ test("snapshot test: no alarms", () => {
   expect(Template.fromStack(stack)).toMatchSnapshot();
 });
 
+test("snapshot test: full restart rate alarm", () => {
+  const stack = new Stack();
+
+  const scope = new TestMonitoringScope(stack, "Scope");
+
+  const monitoring = new KinesisDataAnalyticsMonitoring(scope, {
+    application: "DummyApplication",
+    addFullRestartRateAlarm: {
+      Warning: {
+        maxErrorRate: 0.05,
+      },
+    },
+  });
+
+  addMonitoringDashboardsToStack(stack, monitoring);
+  expect(Template.fromStack(stack)).toMatchSnapshot();
+});
+
 test("snapshot test: all alarms", () => {
   const stack = new Stack();
 
@@ -35,6 +53,11 @@ test("snapshot test: all alarms", () => {
     addFullRestartCountAlarm: {
       Warning: {
         maxFullRestartCount: 1,
+      },
+    },
+    addFullRestartRateAlarm: {
+      Warning: {
+        maxErrorRate: 0.1,
       },
     },
     addCheckpointFailureCountAlarm: {
@@ -55,6 +78,6 @@ test("snapshot test: all alarms", () => {
   });
 
   addMonitoringDashboardsToStack(stack, monitoring);
-  expect(numAlarmsCreated).toStrictEqual(4);
+  expect(numAlarmsCreated).toStrictEqual(5);
   expect(Template.fromStack(stack)).toMatchSnapshot();
 });

--- a/test/monitoring/aws-kinesisanalytics/__snapshots__/KinesisDataAnalyticsMonitoring.test.ts.snap
+++ b/test/monitoring/aws-kinesisanalytics/__snapshots__/KinesisDataAnalyticsMonitoring.test.ts.snap
@@ -45,11 +45,22 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyApplicationFailureCountWarningE827B83F",
+                  "ScopeTestDummyApplicationFullRestartRateWarningE45B3639",
                   "Arn",
                 ],
               },
               "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":18,\\"y\\":0,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyApplicationFailureCountWarningE827B83F",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":0,\\"y\\":4,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -89,11 +100,11 @@ Object {
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"AWS/KinesisAnalytics\\",\\"fullRestarts\\",\\"Application\\",\\"DummyApplication\\",{\\"label\\":\\"Restarts\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Restarts > 1 for 3 datapoints within 15 minutes\\",\\"value\\":1,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Checkpoint Failures\\",\\"region\\":\\"",
+              "\\",\\"metrics\\":[[\\"AWS/KinesisAnalytics\\",\\"fullRestarts\\",\\"Application\\",\\"DummyApplication\\",{\\"label\\":\\"Restarts\\",\\"id\\":\\"fullRestarts\\"}],[{\\"label\\":\\"Full Restart Rate\\",\\"expression\\":\\"RATE(fullRestarts)\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Restarts > 1 for 3 datapoints within 15 minutes\\",\\"value\\":1,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"Full Restart Rate > 0.1 for 3 datapoints within 15 minutes\\",\\"value\\":0.1,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false},\\"right\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Checkpoint Failures\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"AWS/KinesisAnalytics\\",\\"numberOfFailedCheckpoints\\",\\"Application\\",\\"DummyApplication\\",{\\"label\\":\\"Failed Checkpoints\\",\\"stat\\":\\"Sum\\",\\"id\\":\\"checkpoints\\"}],[{\\"label\\":\\"Failed Checkpoints/h\\",\\"expression\\":\\"(3600 * checkpoints) / PERIOD(checkpoints)\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Failed Checkpoints > 5 for 3 datapoints within 15 minutes\\",\\"value\\":5,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"Failed Checkpoints/h > 0.1 for 3 datapoints within 15 minutes\\",\\"value\\":0.1,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false},\\"right\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Checkpoint Duration\\",\\"region\\":\\"",
+              "\\",\\"metrics\\":[[\\"AWS/KinesisAnalytics\\",\\"numberOfFailedCheckpoints\\",\\"Application\\",\\"DummyApplication\\",{\\"label\\":\\"Failed Checkpoints\\",\\"stat\\":\\"Sum\\",\\"id\\":\\"numberOfFailedCheckpoints\\"}],[{\\"label\\":\\"Checkpoint Failure Rate\\",\\"expression\\":\\"RATE(numberOfFailedCheckpoints)\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Failed Checkpoints > 5 for 3 datapoints within 15 minutes\\",\\"value\\":5,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"Checkpoint Failure Rate > 0.1 for 3 datapoints within 15 minutes\\",\\"value\\":0.1,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false},\\"right\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Checkpoint Duration\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -190,12 +201,12 @@ Object {
         "EvaluationPeriods": 3,
         "Metrics": Array [
           Object {
-            "Expression": "(3600 * checkpoints) / PERIOD(checkpoints)",
+            "Expression": "RATE(numberOfFailedCheckpoints)",
             "Id": "expr_1",
-            "Label": "Failed Checkpoints/h",
+            "Label": "Checkpoint Failure Rate",
           },
           Object {
-            "Id": "checkpoints",
+            "Id": "numberOfFailedCheckpoints",
             "Label": "Failed Checkpoints",
             "MetricStat": Object {
               "Metric": Object {
@@ -216,6 +227,45 @@ Object {
         ],
         "Threshold": 0.1,
         "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApplicationFullRestartRateWarningE45B3639": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "Full restart rate is too high",
+        "AlarmName": "Test-DummyApplication-FullRestartRate-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 3,
+        "EvaluationPeriods": 3,
+        "Metrics": Array [
+          Object {
+            "Expression": "RATE(fullRestarts)",
+            "Id": "expr_1",
+            "Label": "Full Restart Rate",
+          },
+          Object {
+            "Id": "fullRestarts",
+            "Label": "Restarts",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "Application",
+                    "Value": "DummyApplication",
+                  },
+                ],
+                "MetricName": "fullRestarts",
+                "Namespace": "AWS/KinesisAnalytics",
+              },
+              "Period": 300,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 0.1,
+        "TreatMissingData": "breaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
@@ -275,7 +325,185 @@ Object {
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"AWS/KinesisAnalytics\\",\\"fullRestarts\\",\\"Application\\",\\"DummyApplication\\",{\\"label\\":\\"Restarts\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Restarts > 1 for 3 datapoints within 15 minutes\\",\\"value\\":1,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}}]}",
+              "\\",\\"metrics\\":[[\\"AWS/KinesisAnalytics\\",\\"fullRestarts\\",\\"Application\\",\\"DummyApplication\\",{\\"label\\":\\"Restarts\\",\\"id\\":\\"fullRestarts\\"}],[{\\"label\\":\\"Full Restart Rate\\",\\"expression\\":\\"RATE(fullRestarts)\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Restarts > 1 for 3 datapoints within 15 minutes\\",\\"value\\":1,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"Full Restart Rate > 0.1 for 3 datapoints within 15 minutes\\",\\"value\\":0.1,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false},\\"right\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`snapshot test: full restart rate alarm 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "Alarm7103F465": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyApplicationFullRestartRateWarningE45B3639",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "Resource": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Kinesis Data Analytics **[DummyApplication](https://eu-west-1.console.aws.amazon.com/kinesisanalytics/home?region=eu-west-1#/details?applicationName=DummyApplication)**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"KPU Usage\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/KinesisAnalytics\\",\\"KPUs\\",\\"Application\\",\\"DummyApplication\\",{\\"label\\":\\"Kinesis Processing Units\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Resource Utilization\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/KinesisAnalytics\\",\\"cpuUtilization\\",\\"Application\\",\\"DummyApplication\\",{\\"label\\":\\"CPU Utilization\\"}],[\\"AWS/KinesisAnalytics\\",\\"heapMemoryUtilization\\",\\"Application\\",\\"DummyApplication\\",{\\"label\\":\\"Heap Memory Utilization\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":100,\\"label\\":\\"%\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":12,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Down Time\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/KinesisAnalytics\\",\\"downtime\\",\\"Application\\",\\"DummyApplication\\",{\\"label\\":\\"Downtime\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":18,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Full Restarts\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/KinesisAnalytics\\",\\"fullRestarts\\",\\"Application\\",\\"DummyApplication\\",{\\"label\\":\\"Restarts\\",\\"id\\":\\"fullRestarts\\"}],[{\\"label\\":\\"Full Restart Rate\\",\\"expression\\":\\"RATE(fullRestarts)\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Full Restart Rate > 0.05 for 3 datapoints within 15 minutes\\",\\"value\\":0.05,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false},\\"right\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Checkpoint Failures\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/KinesisAnalytics\\",\\"numberOfFailedCheckpoints\\",\\"Application\\",\\"DummyApplication\\",{\\"label\\":\\"Failed Checkpoints\\",\\"stat\\":\\"Sum\\",\\"id\\":\\"numberOfFailedCheckpoints\\"}],[{\\"label\\":\\"Checkpoint Failure Rate\\",\\"expression\\":\\"RATE(numberOfFailedCheckpoints)\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false},\\"right\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Checkpoint Duration\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/KinesisAnalytics\\",\\"lastCheckpointDuration\\",\\"Application\\",\\"DummyApplication\\",{\\"label\\":\\"Last Checkpoint Duration\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":12,\\"y\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Checkpoint Size\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/KinesisAnalytics\\",\\"lastCheckpointSize\\",\\"Application\\",\\"DummyApplication\\",{\\"label\\":\\"Last Checkpoint Size\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"bytes\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":18,\\"y\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Garbage Collection\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/KinesisAnalytics\\",\\"oldGenerationGCCount\\",\\"Application\\",\\"DummyApplication\\",{\\"label\\":\\"GC Count\\",\\"stat\\":\\"SampleCount\\"}],[\\"AWS/KinesisAnalytics\\",\\"oldGenerationGCTime\\",\\"Application\\",\\"DummyApplication\\",{\\"label\\":\\"GC Time\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false},\\"right\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "ScopeTestDummyApplicationFullRestartRateWarningE45B3639": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "Full restart rate is too high",
+        "AlarmName": "Test-DummyApplication-FullRestartRate-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 3,
+        "EvaluationPeriods": 3,
+        "Metrics": Array [
+          Object {
+            "Expression": "RATE(fullRestarts)",
+            "Id": "expr_1",
+            "Label": "Full Restart Rate",
+          },
+          Object {
+            "Id": "fullRestarts",
+            "Label": "Restarts",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "Application",
+                    "Value": "DummyApplication",
+                  },
+                ],
+                "MetricName": "fullRestarts",
+                "Namespace": "AWS/KinesisAnalytics",
+              },
+              "Period": 300,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 0.05,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "Summary68521F81": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Kinesis Data Analytics **[DummyApplication](https://eu-west-1.console.aws.amazon.com/kinesisanalytics/home?region=eu-west-1#/details?applicationName=DummyApplication)**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"KPU Usage\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/KinesisAnalytics\\",\\"KPUs\\",\\"Application\\",\\"DummyApplication\\",{\\"label\\":\\"Kinesis Processing Units\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":6,\\"x\\":6,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Resource Utilization\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/KinesisAnalytics\\",\\"cpuUtilization\\",\\"Application\\",\\"DummyApplication\\",{\\"label\\":\\"CPU Utilization\\"}],[\\"AWS/KinesisAnalytics\\",\\"heapMemoryUtilization\\",\\"Application\\",\\"DummyApplication\\",{\\"label\\":\\"Heap Memory Utilization\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":100,\\"label\\":\\"%\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":6,\\"x\\":12,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Down Time\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/KinesisAnalytics\\",\\"downtime\\",\\"Application\\",\\"DummyApplication\\",{\\"label\\":\\"Downtime\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":6,\\"x\\":18,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Full Restarts\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/KinesisAnalytics\\",\\"fullRestarts\\",\\"Application\\",\\"DummyApplication\\",{\\"label\\":\\"Restarts\\",\\"id\\":\\"fullRestarts\\"}],[{\\"label\\":\\"Full Restart Rate\\",\\"expression\\":\\"RATE(fullRestarts)\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Full Restart Rate > 0.05 for 3 datapoints within 15 minutes\\",\\"value\\":0.05,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false},\\"right\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}}]}",
             ],
           ],
         },
@@ -351,11 +579,11 @@ Object {
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"AWS/KinesisAnalytics\\",\\"fullRestarts\\",\\"Application\\",\\"DummyApplication\\",{\\"label\\":\\"Restarts\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Checkpoint Failures\\",\\"region\\":\\"",
+              "\\",\\"metrics\\":[[\\"AWS/KinesisAnalytics\\",\\"fullRestarts\\",\\"Application\\",\\"DummyApplication\\",{\\"label\\":\\"Restarts\\",\\"id\\":\\"fullRestarts\\"}],[{\\"label\\":\\"Full Restart Rate\\",\\"expression\\":\\"RATE(fullRestarts)\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false},\\"right\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Checkpoint Failures\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"AWS/KinesisAnalytics\\",\\"numberOfFailedCheckpoints\\",\\"Application\\",\\"DummyApplication\\",{\\"label\\":\\"Failed Checkpoints\\",\\"stat\\":\\"Sum\\",\\"id\\":\\"checkpoints\\"}],[{\\"label\\":\\"Failed Checkpoints/h\\",\\"expression\\":\\"(3600 * checkpoints) / PERIOD(checkpoints)\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false},\\"right\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Checkpoint Duration\\",\\"region\\":\\"",
+              "\\",\\"metrics\\":[[\\"AWS/KinesisAnalytics\\",\\"numberOfFailedCheckpoints\\",\\"Application\\",\\"DummyApplication\\",{\\"label\\":\\"Failed Checkpoints\\",\\"stat\\":\\"Sum\\",\\"id\\":\\"numberOfFailedCheckpoints\\"}],[{\\"label\\":\\"Checkpoint Failure Rate\\",\\"expression\\":\\"RATE(numberOfFailedCheckpoints)\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false},\\"right\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Checkpoint Duration\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -396,7 +624,7 @@ Object {
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"AWS/KinesisAnalytics\\",\\"fullRestarts\\",\\"Application\\",\\"DummyApplication\\",{\\"label\\":\\"Restarts\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}}]}",
+              "\\",\\"metrics\\":[[\\"AWS/KinesisAnalytics\\",\\"fullRestarts\\",\\"Application\\",\\"DummyApplication\\",{\\"label\\":\\"Restarts\\",\\"id\\":\\"fullRestarts\\"}],[{\\"label\\":\\"Full Restart Rate\\",\\"expression\\":\\"RATE(fullRestarts)\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false},\\"right\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}}]}",
             ],
           ],
         },


### PR DESCRIPTION
feat(kinesisdataanalytics): Fix Checkpoint Failure Rate calculation and add Full Restart Rate monitoring

* Changes
  * Fixed Checkpoint Failure Rate 
    * Replaced manual rate calculation with CloudWatch's native RATE() function 
    * Changed from (3600 * checkpoints) / PERIOD(checkpoints) to RATE(numberOfFailedCheckpoints)
  * Added Full Restart Rate Monitoring 
    * New metricFullRestartRate() method using RATE(fullRestarts)
    * New addFullRestartRateAlarm() with custom implementation to avoid naming conflicts 
    * Enhanced Full Restarts widget to show both count (left axis) and rate (right axis)