### PR TITLE
feat(kinesis): add per-consumer EFO monitoring

### DIFF
--- a/lib/common/monitoring/alarms/KinesisAlarmFactory.ts
+++ b/lib/common/monitoring/alarms/KinesisAlarmFactory.ts
@@ -25,6 +25,17 @@ export interface RecordsFailedThreshold extends CustomAlarmThreshold {
   readonly maxRecordsFailedThreshold: number;
 }
 
+export interface ConsumerRateExceededThreshold extends CustomAlarmThreshold {
+  /** Threshold for SubscribeToShard.RateExceeded average (0.0–1.0). */
+  readonly maxRateExceeded: number;
+}
+
+export interface MinConsumerSubscribeToShardSuccessThreshold
+  extends CustomAlarmThreshold {
+  /** Minimum acceptable SubscribeToShard.Success average (0.0–1.0). */
+  readonly minSuccessRate: number;
+}
+
 export class KinesisAlarmFactory {
   protected readonly alarmFactory: AlarmFactory;
 
@@ -164,6 +175,68 @@ export class KinesisAlarmFactory {
       threshold,
       alarmNameSuffix: "WriteThroughputExceeded",
       alarmDescription: `Number of records resulting in write throughput capacity throttling reached the threshold of ${threshold}.`,
+    });
+  }
+
+  addConsumerIteratorMaxAgeAlarm(
+    metric: MetricWithAlarmSupport,
+    props: MaxIteratorAgeThreshold,
+    disambiguator?: string,
+  ) {
+    return this.alarmFactory.addAlarm(metric, {
+      treatMissingData:
+        props.treatMissingDataOverride ?? TreatMissingData.MISSING,
+      comparisonOperator:
+        props.comparisonOperatorOverride ??
+        ComparisonOperator.GREATER_THAN_THRESHOLD,
+      ...props,
+      disambiguator,
+      threshold: props.maxAgeInMillis,
+      alarmNameSuffix: "ConsumerIteratorMaxAge",
+      alarmDescription: `Consumer SubscribeToShardEvent MillisBehindLatest is too high.`,
+      alarmDedupeStringSuffix: "AnyConsumerIteratorMaxAge",
+    });
+  }
+
+  addConsumerSubscribeToShardRateExceededAlarm(
+    metric: MetricWithAlarmSupport,
+    props: ConsumerRateExceededThreshold,
+    disambiguator?: string,
+  ) {
+    const threshold = props.maxRateExceeded;
+    return this.alarmFactory.addAlarm(metric, {
+      treatMissingData:
+        props.treatMissingDataOverride ?? TreatMissingData.NOT_BREACHING,
+      comparisonOperator:
+        props.comparisonOperatorOverride ??
+        ComparisonOperator.GREATER_THAN_THRESHOLD,
+      ...props,
+      disambiguator,
+      threshold,
+      alarmNameSuffix: "ConsumerSubscribeToShardRateExceeded",
+      alarmDescription: `Consumer SubscribeToShard rate exceeded threshold of ${threshold}.`,
+      alarmDedupeStringSuffix: "ConsumerSubscribeToShardRateExceeded",
+    });
+  }
+
+  addConsumerSubscribeToShardSuccessAlarm(
+    metric: MetricWithAlarmSupport,
+    props: MinConsumerSubscribeToShardSuccessThreshold,
+    disambiguator?: string,
+  ) {
+    const threshold = props.minSuccessRate;
+    return this.alarmFactory.addAlarm(metric, {
+      treatMissingData:
+        props.treatMissingDataOverride ?? TreatMissingData.NOT_BREACHING,
+      comparisonOperator:
+        props.comparisonOperatorOverride ??
+        ComparisonOperator.LESS_THAN_THRESHOLD,
+      ...props,
+      disambiguator,
+      threshold,
+      alarmNameSuffix: "ConsumerSubscribeToShardSuccess",
+      alarmDescription: `Consumer SubscribeToShard success rate fell below threshold of ${threshold}.`,
+      alarmDedupeStringSuffix: "ConsumerSubscribeToShardSuccess",
     });
   }
 }

--- a/lib/facade/IMonitoringAspect.ts
+++ b/lib/facade/IMonitoringAspect.ts
@@ -14,6 +14,7 @@ import {
   ElastiCacheClusterMonitoringOptions,
   GlueJobMonitoringOptions,
   KinesisDataAnalyticsMonitoringOptions,
+  KinesisDataStreamConsumerMonitoringOptions,
   KinesisDataStreamMonitoringOptions,
   KinesisFirehoseMonitoringOptions,
   LambdaFunctionMonitoringOptions,
@@ -112,6 +113,11 @@ export interface KinesisDataStreamAspectType extends BaseMonitoringAspectType {
   readonly props?: KinesisDataStreamMonitoringOptions;
 }
 
+export interface KinesisDataStreamConsumerAspectType
+  extends BaseMonitoringAspectType {
+  readonly props?: KinesisDataStreamConsumerMonitoringOptions;
+}
+
 export interface KinesisFirehoseAspectType extends BaseMonitoringAspectType {
   readonly props?: KinesisFirehoseMonitoringOptions;
 }
@@ -182,6 +188,7 @@ export interface MonitoringAspectProps {
   readonly glue?: GlueJobAspectType;
   readonly kinesisDataAnalytics?: KinesisDataAnalyticsAspectType;
   readonly kinesisDataStream?: KinesisDataStreamAspectType;
+  readonly kinesisDataStreamConsumer?: KinesisDataStreamConsumerAspectType;
   readonly kinesisFirehose?: KinesisFirehoseAspectType;
   readonly lambda?: LambdaFunctionAspectType;
   readonly openSearch?: OpenSearchClusterAspectType;

--- a/lib/facade/MonitoringAspect.ts
+++ b/lib/facade/MonitoringAspect.ts
@@ -1,4 +1,4 @@
-import { IAspect, Stack } from "aws-cdk-lib";
+import { IAspect, Stack, Arn, ArnFormat } from "aws-cdk-lib";
 import * as apigw from "aws-cdk-lib/aws-apigateway";
 import * as apigwv2 from "aws-cdk-lib/aws-apigatewayv2";
 import * as appsync from "aws-cdk-lib/aws-appsync";
@@ -61,6 +61,7 @@ export class MonitoringAspect implements IAspect {
     this.monitorGlue(node);
     this.monitorKinesisAnalytics(node);
     this.monitorKinesisDataStream(node);
+    this.monitorKinesisDataStreamConsumer(node);
     this.monitorKinesisFirehose(node);
     this.monitorLambda(node);
     this.monitorOpenSearch(node);
@@ -268,6 +269,24 @@ export class MonitoringAspect implements IAspect {
     if (isEnabled && node instanceof kinesis.CfnStream) {
       this.monitoringFacade.monitorKinesisDataStream({
         streamName: node.name!,
+        alarmFriendlyName: node.node.path,
+        ...props,
+      });
+    }
+  }
+
+  private monitorKinesisDataStreamConsumer(node: IConstruct) {
+    const [isEnabled, props] = this.getMonitoringDetails(
+      this.props.kinesisDataStreamConsumer,
+    );
+    if (isEnabled && node instanceof kinesis.CfnStreamConsumer) {
+      const streamName = Arn.split(
+        node.streamArn,
+        ArnFormat.SLASH_RESOURCE_NAME,
+      ).resourceName!;
+      this.monitoringFacade.monitorKinesisDataStreamConsumer({
+        streamName,
+        consumerName: node.consumerName,
         alarmFriendlyName: node.node.path,
         ...props,
       });

--- a/lib/facade/MonitoringFacade.ts
+++ b/lib/facade/MonitoringFacade.ts
@@ -81,6 +81,8 @@ import {
   GlueJobMonitoringProps,
   KinesisDataAnalyticsMonitoring,
   KinesisDataAnalyticsMonitoringProps,
+  KinesisDataStreamConsumerMonitoring,
+  KinesisDataStreamConsumerMonitoringProps,
   KinesisDataStreamMonitoring,
   KinesisDataStreamMonitoringProps,
   KinesisFirehoseMonitoring,
@@ -762,6 +764,14 @@ export class MonitoringFacade extends MonitoringScope {
 
   monitorKinesisDataStream(props: KinesisDataStreamMonitoringProps): this {
     const segment = new KinesisDataStreamMonitoring(this, props);
+    this.addSegment(segment, props);
+    return this;
+  }
+
+  monitorKinesisDataStreamConsumer(
+    props: KinesisDataStreamConsumerMonitoringProps,
+  ): this {
+    const segment = new KinesisDataStreamConsumerMonitoring(this, props);
     this.addSegment(segment, props);
     return this;
   }

--- a/lib/monitoring/aws-kinesis/KinesisDataStreamConsumerMetricFactory.ts
+++ b/lib/monitoring/aws-kinesis/KinesisDataStreamConsumerMetricFactory.ts
@@ -1,0 +1,127 @@
+import { DimensionsMap } from "aws-cdk-lib/aws-cloudwatch";
+
+import {
+  BaseMetricFactory,
+  BaseMetricFactoryProps,
+  MetricFactory,
+  MetricStatistic,
+} from "../../common";
+
+const DataStreamNamespace = "AWS/Kinesis";
+
+export interface KinesisDataStreamConsumerMetricFactoryProps
+  extends BaseMetricFactoryProps {
+  readonly streamName: string;
+  readonly consumerName: string;
+}
+
+/**
+ * Metrics for a single enhanced fan-out (EFO) consumer of a Kinesis data stream.
+ * Dimensions: {StreamName, ConsumerName}.
+ *
+ * @see https://docs.aws.amazon.com/streams/latest/dev/monitoring-with-cloudwatch.html#kinesis-metrics-consumer
+ */
+export class KinesisDataStreamConsumerMetricFactory extends BaseMetricFactory<KinesisDataStreamConsumerMetricFactoryProps> {
+  protected readonly dimensionsMap: DimensionsMap;
+
+  constructor(
+    metricFactory: MetricFactory,
+    props: KinesisDataStreamConsumerMetricFactoryProps,
+  ) {
+    super(metricFactory, props);
+    this.dimensionsMap = {
+      StreamName: props.streamName,
+      ConsumerName: props.consumerName,
+    };
+  }
+
+  /** Max lag (ms) for events delivered to this EFO consumer. */
+  metricSubscribeToShardEventMillisBehindLatestMaxMs() {
+    return this.metricFactory.createMetric(
+      "SubscribeToShardEvent.MillisBehindLatest",
+      MetricStatistic.MAX,
+      "Millis Behind Latest",
+      this.dimensionsMap,
+      undefined,
+      DataStreamNamespace,
+      undefined,
+      this.region,
+      this.account,
+    );
+  }
+
+  /** Rate at which SubscribeToShard calls for this consumer are throttled. */
+  metricSubscribeToShardRateExceededAverage() {
+    return this.metricFactory.createMetric(
+      "SubscribeToShard.RateExceeded",
+      MetricStatistic.AVERAGE,
+      "Rate Exceeded",
+      this.dimensionsMap,
+      undefined,
+      DataStreamNamespace,
+      undefined,
+      this.region,
+      this.account,
+    );
+  }
+
+  /** Success rate of SubscribeToShard calls (connect handshake). */
+  metricSubscribeToShardSuccessAverage() {
+    return this.metricFactory.createMetric(
+      "SubscribeToShard.Success",
+      MetricStatistic.AVERAGE,
+      "Subscribe Success",
+      this.dimensionsMap,
+      undefined,
+      DataStreamNamespace,
+      undefined,
+      this.region,
+      this.account,
+    );
+  }
+
+  /** Success rate of individual SubscribeToShardEvent deliveries within an open subscription. */
+  metricSubscribeToShardEventSuccessAverage() {
+    return this.metricFactory.createMetric(
+      "SubscribeToShardEvent.Success",
+      MetricStatistic.AVERAGE,
+      "Event Success",
+      this.dimensionsMap,
+      undefined,
+      DataStreamNamespace,
+      undefined,
+      this.region,
+      this.account,
+    );
+  }
+
+  /** Records delivered to this consumer. */
+  metricSubscribeToShardEventRecordsSumCount() {
+    return this.metricFactory.createMetric(
+      "SubscribeToShardEvent.Records",
+      MetricStatistic.SUM,
+      "Records",
+      this.dimensionsMap,
+      undefined,
+      DataStreamNamespace,
+      undefined,
+      this.region,
+      this.account,
+    );
+  }
+
+  /** Bytes delivered to this consumer. */
+  metricSubscribeToShardEventSumBytes() {
+    return this.metricFactory.createMetric(
+      "SubscribeToShardEvent.Bytes",
+      MetricStatistic.SUM,
+      "Bytes",
+      this.dimensionsMap,
+      undefined,
+      DataStreamNamespace,
+      undefined,
+      this.region,
+      this.account,
+    );
+  }
+}

--- a/lib/monitoring/aws-kinesis/KinesisDataStreamConsumerMonitoring.ts
+++ b/lib/monitoring/aws-kinesis/KinesisDataStreamConsumerMonitoring.ts
@@ -1,0 +1,250 @@
+import {
+  GraphWidget,
+  HorizontalAnnotation,
+  IWidget,
+  Row,
+} from "aws-cdk-lib/aws-cloudwatch";
+
+import {
+  KinesisDataStreamConsumerMetricFactory,
+  KinesisDataStreamConsumerMetricFactoryProps,
+} from "./KinesisDataStreamConsumerMetricFactory";
+import {
+  BaseMonitoringProps,
+  ConsumerRateExceededThreshold,
+  CountAxisFromZero,
+  DefaultGraphWidgetHeight,
+  DefaultSummaryWidgetHeight,
+  HalfWidth,
+  KinesisAlarmFactory,
+  MaxIteratorAgeThreshold,
+  MetricWithAlarmSupport,
+  MinConsumerSubscribeToShardSuccessThreshold,
+  Monitoring,
+  MonitoringScope,
+  QuarterWidth,
+  RateAxisFromZeroToOne,
+  SizeAxisBytesFromZero,
+  TimeAxisMillisFromZero,
+} from "../../common";
+import {
+  MonitoringHeaderWidget,
+  MonitoringNamingStrategy,
+} from "../../dashboard";
+
+export interface KinesisDataStreamConsumerMonitoringOptions
+  extends BaseMonitoringProps {
+  readonly addConsumerIteratorMaxAgeAlarm?: Record<
+    string,
+    MaxIteratorAgeThreshold
+  >;
+  readonly addConsumerSubscribeToShardRateExceededAlarm?: Record<
+    string,
+    ConsumerRateExceededThreshold
+  >;
+  readonly addConsumerSubscribeToShardSuccessAlarm?: Record<
+    string,
+    MinConsumerSubscribeToShardSuccessThreshold
+  >;
+}
+
+export interface KinesisDataStreamConsumerMonitoringProps
+  extends KinesisDataStreamConsumerMetricFactoryProps,
+    KinesisDataStreamConsumerMonitoringOptions {}
+
+export class KinesisDataStreamConsumerMonitoring extends Monitoring {
+  readonly title: string;
+  readonly streamUrl?: string;
+
+  readonly kinesisAlarmFactory: KinesisAlarmFactory;
+  readonly ageAnnotations: HorizontalAnnotation[];
+  readonly rateExceededAnnotations: HorizontalAnnotation[];
+  readonly subscribeSuccessAnnotations: HorizontalAnnotation[];
+
+  readonly millisBehindLatestMetric: MetricWithAlarmSupport;
+  readonly rateExceededMetric: MetricWithAlarmSupport;
+  readonly subscribeToShardSuccessMetric: MetricWithAlarmSupport;
+  readonly subscribeToShardEventSuccessMetric: MetricWithAlarmSupport;
+  readonly recordsMetric: MetricWithAlarmSupport;
+  readonly bytesMetric: MetricWithAlarmSupport;
+
+  constructor(
+    scope: MonitoringScope,
+    props: KinesisDataStreamConsumerMonitoringProps,
+  ) {
+    super(scope, props);
+
+    const namingStrategy = new MonitoringNamingStrategy({
+      ...props,
+      fallbackConstructName: `${props.streamName}-${props.consumerName}`,
+    });
+    this.title = namingStrategy.resolveHumanReadableName();
+    this.streamUrl = scope
+      .createAwsConsoleUrlFactory()
+      .getKinesisDataStreamUrl(props.streamName);
+
+    const alarmFactory = this.createAlarmFactory(
+      namingStrategy.resolveAlarmFriendlyName(),
+    );
+    this.kinesisAlarmFactory = new KinesisAlarmFactory(alarmFactory);
+    this.ageAnnotations = [];
+    this.rateExceededAnnotations = [];
+    this.subscribeSuccessAnnotations = [];
+
+    const metricFactory = new KinesisDataStreamConsumerMetricFactory(
+      scope.createMetricFactory(),
+      props,
+    );
+    this.millisBehindLatestMetric =
+      metricFactory.metricSubscribeToShardEventMillisBehindLatestMaxMs();
+    this.rateExceededMetric =
+      metricFactory.metricSubscribeToShardRateExceededAverage();
+    this.subscribeToShardSuccessMetric =
+      metricFactory.metricSubscribeToShardSuccessAverage();
+    this.subscribeToShardEventSuccessMetric =
+      metricFactory.metricSubscribeToShardEventSuccessAverage();
+    this.recordsMetric =
+      metricFactory.metricSubscribeToShardEventRecordsSumCount();
+    this.bytesMetric = metricFactory.metricSubscribeToShardEventSumBytes();
+
+    for (const disambiguator in props.addConsumerIteratorMaxAgeAlarm) {
+      const alarmProps = props.addConsumerIteratorMaxAgeAlarm[disambiguator];
+      const createdAlarm =
+        this.kinesisAlarmFactory.addConsumerIteratorMaxAgeAlarm(
+          this.millisBehindLatestMetric,
+          alarmProps,
+          disambiguator,
+        );
+      this.ageAnnotations.push(createdAlarm.annotation);
+      this.addAlarm(createdAlarm);
+    }
+    for (const disambiguator in props.addConsumerSubscribeToShardRateExceededAlarm) {
+      const alarmProps =
+        props.addConsumerSubscribeToShardRateExceededAlarm[disambiguator];
+      const createdAlarm =
+        this.kinesisAlarmFactory.addConsumerSubscribeToShardRateExceededAlarm(
+          this.rateExceededMetric,
+          alarmProps,
+          disambiguator,
+        );
+      this.rateExceededAnnotations.push(createdAlarm.annotation);
+      this.addAlarm(createdAlarm);
+    }
+    for (const disambiguator in props.addConsumerSubscribeToShardSuccessAlarm) {
+      const alarmProps =
+        props.addConsumerSubscribeToShardSuccessAlarm[disambiguator];
+      const createdAlarm =
+        this.kinesisAlarmFactory.addConsumerSubscribeToShardSuccessAlarm(
+          this.subscribeToShardSuccessMetric,
+          alarmProps,
+          disambiguator,
+        );
+      this.subscribeSuccessAnnotations.push(createdAlarm.annotation);
+      this.addAlarm(createdAlarm);
+    }
+
+    props.useCreatedAlarms?.consume(this.createdAlarms());
+  }
+
+  summaryWidgets(): IWidget[] {
+    return [
+      this.createTitleWidget(),
+      new Row(
+        this.createMillisBehindLatestWidget(
+          QuarterWidth,
+          DefaultSummaryWidgetHeight,
+        ),
+        this.createSubscribeSuccessWidget(
+          QuarterWidth,
+          DefaultSummaryWidgetHeight,
+        ),
+        this.createRateExceededWidget(QuarterWidth, DefaultSummaryWidgetHeight),
+      ),
+    ];
+  }
+
+  widgets(): IWidget[] {
+    return [
+      this.createTitleWidget(),
+      new Row(
+        this.createMillisBehindLatestWidget(
+          QuarterWidth,
+          DefaultGraphWidgetHeight,
+        ),
+        this.createSubscribeSuccessWidget(
+          QuarterWidth,
+          DefaultGraphWidgetHeight,
+        ),
+        this.createRateExceededWidget(QuarterWidth, DefaultGraphWidgetHeight),
+      ),
+      new Row(
+        this.createRecordsWidget(HalfWidth, DefaultGraphWidgetHeight),
+        this.createBytesWidget(HalfWidth, DefaultGraphWidgetHeight),
+      ),
+    ];
+  }
+
+  createTitleWidget() {
+    return new MonitoringHeaderWidget({
+      family: "Kinesis Data Stream Consumer",
+      title: this.title,
+      goToLinkUrl: this.streamUrl,
+    });
+  }
+
+  createMillisBehindLatestWidget(width: number, height: number) {
+    return new GraphWidget({
+      width,
+      height,
+      title: "Iterator (Consumer)",
+      left: [this.millisBehindLatestMetric],
+      leftAnnotations: this.ageAnnotations,
+      leftYAxis: TimeAxisMillisFromZero,
+    });
+  }
+
+  createSubscribeSuccessWidget(width: number, height: number) {
+    return new GraphWidget({
+      width,
+      height,
+      title: "Subscribe Success",
+      left: [
+        this.subscribeToShardSuccessMetric,
+        this.subscribeToShardEventSuccessMetric,
+      ],
+      leftAnnotations: this.subscribeSuccessAnnotations,
+      leftYAxis: RateAxisFromZeroToOne,
+    });
+  }
+
+  createRateExceededWidget(width: number, height: number) {
+    return new GraphWidget({
+      width,
+      height,
+      title: "Rate Exceeded",
+      left: [this.rateExceededMetric],
+      leftAnnotations: this.rateExceededAnnotations,
+      leftYAxis: RateAxisFromZeroToOne,
+    });
+  }
+
+  createRecordsWidget(width: number, height: number) {
+    return new GraphWidget({
+      width,
+      height,
+      title: "Records",
+      left: [this.recordsMetric],
+      leftYAxis: CountAxisFromZero,
+    });
+  }
+
+  createBytesWidget(width: number, height: number) {
+    return new GraphWidget({
+      width,
+      height,
+      title: "Bytes",
+      left: [this.bytesMetric],
+      leftYAxis: SizeAxisBytesFromZero,
+    });
+  }
+}

--- a/lib/monitoring/aws-kinesis/index.ts
+++ b/lib/monitoring/aws-kinesis/index.ts
@@ -1,3 +1,5 @@
+export * from "./KinesisDataStreamConsumerMetricFactory";
+export * from "./KinesisDataStreamConsumerMonitoring";
 export * from "./KinesisDataStreamMetricFactory";
 export * from "./KinesisFirehoseMetricFactory";
 export * from "./KinesisDataStreamMonitoring";

--- a/test/facade/MonitoringAspect.test.ts
+++ b/test/facade/MonitoringAspect.test.ts
@@ -402,6 +402,24 @@ describe("MonitoringAspect", () => {
       // THEN
       expect(Template.fromStack(stack)).toMatchSnapshot();
     });
+
+    test("DataStreamConsumer", () => {
+      // GIVEN
+      const stack = new Stack();
+      const facade = createDummyMonitoringFacade(stack);
+
+      new kinesis.CfnStreamConsumer(stack, "DummyStreamConsumer", {
+        consumerName: "my-consumer",
+        streamArn:
+          "arn:aws:kinesis:us-east-1:123456789012:stream/my-kinesis-data-stream",
+      });
+
+      // WHEN
+      facade.monitorScope(stack, defaultAspectProps);
+
+      // THEN
+      expect(Template.fromStack(stack)).toMatchSnapshot();
+    });
   });
 
   test("Lambda", () => {

--- a/test/facade/__snapshots__/MonitoringAspect.test.ts.snap
+++ b/test/facade/__snapshots__/MonitoringAspect.test.ts.snap
@@ -5095,6 +5095,137 @@ Object {
 }
 `;
 
+exports[`MonitoringAspect Kinesis DataStreamConsumer 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "DashboardFactoryAlarmDashboard6286FAD3": Object {
+      "Properties": Object {
+        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
+        "DashboardName": "DummyDashboard-Alarms",
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "DashboardFactoryDashboard3E20AD6E": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Kinesis Data Stream Consumer **[my-kinesis-data-stream-my-consumer](https://",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ".console.aws.amazon.com/kinesis/home?region=",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "#/streams/details/my-kinesis-data-stream/monitoring)**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Iterator (Consumer)\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Kinesis\\",\\"SubscribeToShardEvent.MillisBehindLatest\\",\\"ConsumerName\\",\\"my-consumer\\",\\"StreamName\\",\\"my-kinesis-data-stream\\",{\\"label\\":\\"Millis Behind Latest\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Subscribe Success\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Kinesis\\",\\"SubscribeToShard.Success\\",\\"ConsumerName\\",\\"my-consumer\\",\\"StreamName\\",\\"my-kinesis-data-stream\\",{\\"label\\":\\"Subscribe Success\\"}],[\\"AWS/Kinesis\\",\\"SubscribeToShardEvent.Success\\",\\"ConsumerName\\",\\"my-consumer\\",\\"StreamName\\",\\"my-kinesis-data-stream\\",{\\"label\\":\\"Event Success\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":1,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":12,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Rate Exceeded\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Kinesis\\",\\"SubscribeToShard.RateExceeded\\",\\"ConsumerName\\",\\"my-consumer\\",\\"StreamName\\",\\"my-kinesis-data-stream\\",{\\"label\\":\\"Rate Exceeded\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":1,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":5,\\"x\\":0,\\"y\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Records\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Kinesis\\",\\"SubscribeToShardEvent.Records\\",\\"ConsumerName\\",\\"my-consumer\\",\\"StreamName\\",\\"my-kinesis-data-stream\\",{\\"label\\":\\"Records\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":5,\\"x\\":12,\\"y\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Bytes\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Kinesis\\",\\"SubscribeToShardEvent.Bytes\\",\\"ConsumerName\\",\\"my-consumer\\",\\"StreamName\\",\\"my-kinesis-data-stream\\",{\\"label\\":\\"Bytes\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"bytes\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+        "DashboardName": "DummyDashboard",
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "DashboardFactorySummaryDashboard5F4BC8C5": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"start\\":\\"-P14D\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Kinesis Data Stream Consumer **[my-kinesis-data-stream-my-consumer](https://",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ".console.aws.amazon.com/kinesis/home?region=",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "#/streams/details/my-kinesis-data-stream/monitoring)**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Iterator (Consumer)\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Kinesis\\",\\"SubscribeToShardEvent.MillisBehindLatest\\",\\"ConsumerName\\",\\"my-consumer\\",\\"StreamName\\",\\"my-kinesis-data-stream\\",{\\"label\\":\\"Millis Behind Latest\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":6,\\"x\\":6,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Subscribe Success\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Kinesis\\",\\"SubscribeToShard.Success\\",\\"ConsumerName\\",\\"my-consumer\\",\\"StreamName\\",\\"my-kinesis-data-stream\\",{\\"label\\":\\"Subscribe Success\\"}],[\\"AWS/Kinesis\\",\\"SubscribeToShardEvent.Success\\",\\"ConsumerName\\",\\"my-consumer\\",\\"StreamName\\",\\"my-kinesis-data-stream\\",{\\"label\\":\\"Event Success\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":1,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":6,\\"x\\":12,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Rate Exceeded\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Kinesis\\",\\"SubscribeToShard.RateExceeded\\",\\"ConsumerName\\",\\"my-consumer\\",\\"StreamName\\",\\"my-kinesis-data-stream\\",{\\"label\\":\\"Rate Exceeded\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":1,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+        "DashboardName": "DummyDashboard-Summary",
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "DummyStreamConsumer": Object {
+      "Properties": Object {
+        "ConsumerName": "my-consumer",
+        "StreamARN": "arn:aws:kinesis:us-east-1:123456789012:stream/my-kinesis-data-stream",
+      },
+      "Type": "AWS::Kinesis::StreamConsumer",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
 exports[`MonitoringAspect Kinesis Firehose 1`] = `
 Object {
   "Parameters": Object {

--- a/test/monitoring/aws-kinesis/KinesisDataStreamConsumerMonitoring.test.ts
+++ b/test/monitoring/aws-kinesis/KinesisDataStreamConsumerMonitoring.test.ts
@@ -1,0 +1,55 @@
+import { Stack } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+
+import { KinesisDataStreamConsumerMonitoring } from "../../../lib";
+import { addMonitoringDashboardsToStack } from "../../utils/SnapshotUtil";
+import { TestMonitoringScope } from "../TestMonitoringScope";
+
+test("snapshot test for consumer: no alarms", () => {
+  const stack = new Stack();
+  const scope = new TestMonitoringScope(stack, "Scope");
+
+  const monitoring = new KinesisDataStreamConsumerMonitoring(scope, {
+    streamName: "my-kinesis-data-stream",
+    consumerName: "my-consumer",
+  });
+
+  addMonitoringDashboardsToStack(stack, monitoring);
+  expect(Template.fromStack(stack)).toMatchSnapshot();
+});
+
+test("snapshot test for consumer: all alarms", () => {
+  const stack = new Stack();
+  const scope = new TestMonitoringScope(stack, "Scope");
+
+  let numAlarmsCreated = 0;
+
+  const monitoring = new KinesisDataStreamConsumerMonitoring(scope, {
+    streamName: "my-kinesis-data-stream",
+    consumerName: "my-consumer",
+    addConsumerIteratorMaxAgeAlarm: {
+      Warning: {
+        maxAgeInMillis: 60_000,
+      },
+    },
+    addConsumerSubscribeToShardRateExceededAlarm: {
+      Critical: {
+        maxRateExceeded: 0.1,
+      },
+    },
+    addConsumerSubscribeToShardSuccessAlarm: {
+      Critical: {
+        minSuccessRate: 0.99,
+      },
+    },
+    useCreatedAlarms: {
+      consume(alarms) {
+        numAlarmsCreated = alarms.length;
+      },
+    },
+  });
+
+  expect(numAlarmsCreated).toStrictEqual(3);
+  addMonitoringDashboardsToStack(stack, monitoring);
+  expect(Template.fromStack(stack)).toMatchSnapshot();
+});

--- a/test/monitoring/aws-kinesis/__snapshots__/KinesisDataStreamConsumerMonitoring.test.ts.snap
+++ b/test/monitoring/aws-kinesis/__snapshots__/KinesisDataStreamConsumerMonitoring.test.ts.snap
@@ -1,0 +1,365 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snapshot test for consumer: all alarms 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "Alarm7103F465": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestmykinesisdatastreammyconsumerConsumerIteratorMaxAgeWarningA155FD0F",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":6,\\"y\\":0,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestmykinesisdatastreammyconsumerConsumerSubscribeToShardRateExceededCritical2CEB5848",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":12,\\"y\\":0,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestmykinesisdatastreammyconsumerConsumerSubscribeToShardSuccessCritical32679BCB",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "Resource": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Kinesis Data Stream Consumer **[my-kinesis-data-stream-my-consumer](https://eu-west-1.console.aws.amazon.com/kinesis/home?region=eu-west-1#/streams/details/my-kinesis-data-stream/monitoring)**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Iterator (Consumer)\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Kinesis\\",\\"SubscribeToShardEvent.MillisBehindLatest\\",\\"ConsumerName\\",\\"my-consumer\\",\\"StreamName\\",\\"my-kinesis-data-stream\\",{\\"label\\":\\"Millis Behind Latest\\",\\"stat\\":\\"Maximum\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Millis Behind Latest > 60000 for 3 datapoints within 15 minutes\\",\\"value\\":60000,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Subscribe Success\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Kinesis\\",\\"SubscribeToShard.Success\\",\\"ConsumerName\\",\\"my-consumer\\",\\"StreamName\\",\\"my-kinesis-data-stream\\",{\\"label\\":\\"Subscribe Success\\"}],[\\"AWS/Kinesis\\",\\"SubscribeToShardEvent.Success\\",\\"ConsumerName\\",\\"my-consumer\\",\\"StreamName\\",\\"my-kinesis-data-stream\\",{\\"label\\":\\"Event Success\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Subscribe Success < 0.99 for 3 datapoints within 15 minutes\\",\\"value\\":0.99,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":1,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":12,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Rate Exceeded\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Kinesis\\",\\"SubscribeToShard.RateExceeded\\",\\"ConsumerName\\",\\"my-consumer\\",\\"StreamName\\",\\"my-kinesis-data-stream\\",{\\"label\\":\\"Rate Exceeded\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Rate Exceeded > 0.1 for 3 datapoints within 15 minutes\\",\\"value\\":0.1,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":1,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":5,\\"x\\":0,\\"y\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Records\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Kinesis\\",\\"SubscribeToShardEvent.Records\\",\\"ConsumerName\\",\\"my-consumer\\",\\"StreamName\\",\\"my-kinesis-data-stream\\",{\\"label\\":\\"Records\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":5,\\"x\\":12,\\"y\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Bytes\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Kinesis\\",\\"SubscribeToShardEvent.Bytes\\",\\"ConsumerName\\",\\"my-consumer\\",\\"StreamName\\",\\"my-kinesis-data-stream\\",{\\"label\\":\\"Bytes\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"bytes\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "ScopeTestmykinesisdatastreammyconsumerConsumerIteratorMaxAgeWarningA155FD0F": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "Consumer SubscribeToShardEvent MillisBehindLatest is too high.",
+        "AlarmName": "Test-my-kinesis-data-stream-my-consumer-ConsumerIteratorMaxAge-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 3,
+        "EvaluationPeriods": 3,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "Millis Behind Latest",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ConsumerName",
+                    "Value": "my-consumer",
+                  },
+                  Object {
+                    "Name": "StreamName",
+                    "Value": "my-kinesis-data-stream",
+                  },
+                ],
+                "MetricName": "SubscribeToShardEvent.MillisBehindLatest",
+                "Namespace": "AWS/Kinesis",
+              },
+              "Period": 300,
+              "Stat": "Maximum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 60000,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestmykinesisdatastreammyconsumerConsumerSubscribeToShardRateExceededCritical2CEB5848": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "Consumer SubscribeToShard rate exceeded threshold of 0.1.",
+        "AlarmName": "Test-my-kinesis-data-stream-my-consumer-ConsumerSubscribeToShardRateExceeded-Critical",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 3,
+        "EvaluationPeriods": 3,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "Rate Exceeded",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ConsumerName",
+                    "Value": "my-consumer",
+                  },
+                  Object {
+                    "Name": "StreamName",
+                    "Value": "my-kinesis-data-stream",
+                  },
+                ],
+                "MetricName": "SubscribeToShard.RateExceeded",
+                "Namespace": "AWS/Kinesis",
+              },
+              "Period": 300,
+              "Stat": "Average",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 0.1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestmykinesisdatastreammyconsumerConsumerSubscribeToShardSuccessCritical32679BCB": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "Consumer SubscribeToShard success rate fell below threshold of 0.99.",
+        "AlarmName": "Test-my-kinesis-data-stream-my-consumer-ConsumerSubscribeToShardSuccess-Critical",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 3,
+        "EvaluationPeriods": 3,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "Subscribe Success",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ConsumerName",
+                    "Value": "my-consumer",
+                  },
+                  Object {
+                    "Name": "StreamName",
+                    "Value": "my-kinesis-data-stream",
+                  },
+                ],
+                "MetricName": "SubscribeToShard.Success",
+                "Namespace": "AWS/Kinesis",
+              },
+              "Period": 300,
+              "Stat": "Average",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 0.99,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "Summary68521F81": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Kinesis Data Stream Consumer **[my-kinesis-data-stream-my-consumer](https://eu-west-1.console.aws.amazon.com/kinesis/home?region=eu-west-1#/streams/details/my-kinesis-data-stream/monitoring)**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Iterator (Consumer)\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Kinesis\\",\\"SubscribeToShardEvent.MillisBehindLatest\\",\\"ConsumerName\\",\\"my-consumer\\",\\"StreamName\\",\\"my-kinesis-data-stream\\",{\\"label\\":\\"Millis Behind Latest\\",\\"stat\\":\\"Maximum\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Millis Behind Latest > 60000 for 3 datapoints within 15 minutes\\",\\"value\\":60000,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":6,\\"x\\":6,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Subscribe Success\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Kinesis\\",\\"SubscribeToShard.Success\\",\\"ConsumerName\\",\\"my-consumer\\",\\"StreamName\\",\\"my-kinesis-data-stream\\",{\\"label\\":\\"Subscribe Success\\"}],[\\"AWS/Kinesis\\",\\"SubscribeToShardEvent.Success\\",\\"ConsumerName\\",\\"my-consumer\\",\\"StreamName\\",\\"my-kinesis-data-stream\\",{\\"label\\":\\"Event Success\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Subscribe Success < 0.99 for 3 datapoints within 15 minutes\\",\\"value\\":0.99,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":1,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":6,\\"x\\":12,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Rate Exceeded\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Kinesis\\",\\"SubscribeToShard.RateExceeded\\",\\"ConsumerName\\",\\"my-consumer\\",\\"StreamName\\",\\"my-kinesis-data-stream\\",{\\"label\\":\\"Rate Exceeded\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Rate Exceeded > 0.1 for 3 datapoints within 15 minutes\\",\\"value\\":0.1,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":1,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`snapshot test for consumer: no alarms 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "Alarm7103F465": Object {
+      "Properties": Object {
+        "DashboardBody": "{\\"widgets\\":[]}",
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "Resource": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Kinesis Data Stream Consumer **[my-kinesis-data-stream-my-consumer](https://eu-west-1.console.aws.amazon.com/kinesis/home?region=eu-west-1#/streams/details/my-kinesis-data-stream/monitoring)**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Iterator (Consumer)\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Kinesis\\",\\"SubscribeToShardEvent.MillisBehindLatest\\",\\"ConsumerName\\",\\"my-consumer\\",\\"StreamName\\",\\"my-kinesis-data-stream\\",{\\"label\\":\\"Millis Behind Latest\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Subscribe Success\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Kinesis\\",\\"SubscribeToShard.Success\\",\\"ConsumerName\\",\\"my-consumer\\",\\"StreamName\\",\\"my-kinesis-data-stream\\",{\\"label\\":\\"Subscribe Success\\"}],[\\"AWS/Kinesis\\",\\"SubscribeToShardEvent.Success\\",\\"ConsumerName\\",\\"my-consumer\\",\\"StreamName\\",\\"my-kinesis-data-stream\\",{\\"label\\":\\"Event Success\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":1,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":12,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Rate Exceeded\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Kinesis\\",\\"SubscribeToShard.RateExceeded\\",\\"ConsumerName\\",\\"my-consumer\\",\\"StreamName\\",\\"my-kinesis-data-stream\\",{\\"label\\":\\"Rate Exceeded\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":1,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":5,\\"x\\":0,\\"y\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Records\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Kinesis\\",\\"SubscribeToShardEvent.Records\\",\\"ConsumerName\\",\\"my-consumer\\",\\"StreamName\\",\\"my-kinesis-data-stream\\",{\\"label\\":\\"Records\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":5,\\"x\\":12,\\"y\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Bytes\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Kinesis\\",\\"SubscribeToShardEvent.Bytes\\",\\"ConsumerName\\",\\"my-consumer\\",\\"StreamName\\",\\"my-kinesis-data-stream\\",{\\"label\\":\\"Bytes\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"bytes\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "Summary68521F81": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Kinesis Data Stream Consumer **[my-kinesis-data-stream-my-consumer](https://eu-west-1.console.aws.amazon.com/kinesis/home?region=eu-west-1#/streams/details/my-kinesis-data-stream/monitoring)**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Iterator (Consumer)\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Kinesis\\",\\"SubscribeToShardEvent.MillisBehindLatest\\",\\"ConsumerName\\",\\"my-consumer\\",\\"StreamName\\",\\"my-kinesis-data-stream\\",{\\"label\\":\\"Millis Behind Latest\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":6,\\"x\\":6,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Subscribe Success\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Kinesis\\",\\"SubscribeToShard.Success\\",\\"ConsumerName\\",\\"my-consumer\\",\\"StreamName\\",\\"my-kinesis-data-stream\\",{\\"label\\":\\"Subscribe Success\\"}],[\\"AWS/Kinesis\\",\\"SubscribeToShardEvent.Success\\",\\"ConsumerName\\",\\"my-consumer\\",\\"StreamName\\",\\"my-kinesis-data-stream\\",{\\"label\\":\\"Event Success\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":1,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":6,\\"x\\":12,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Rate Exceeded\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Kinesis\\",\\"SubscribeToShard.RateExceeded\\",\\"ConsumerName\\",\\"my-consumer\\",\\"StreamName\\",\\"my-kinesis-data-stream\\",{\\"label\\":\\"Rate Exceeded\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":1,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;


### PR DESCRIPTION
## Summary

Adds `KinesisDataStreamConsumerMonitoring` for enhanced fan-out (EFO) consumers of Kinesis Data Streams, dimensioned by `{StreamName, ConsumerName}`. Complements the existing stream-level `KinesisDataStreamMonitoring` which only covers stream-wide metrics.

## Metrics (6)

All on namespace `AWS/Kinesis`, dims `{StreamName, ConsumerName}`:

| Metric | Stat | Purpose |
|---|---|---|
| `SubscribeToShardEvent.MillisBehindLatest` | MAX | Consumer lag |
| `SubscribeToShard.RateExceeded` | AVG | Connect-call throttling |
| `SubscribeToShard.Success` | AVG | Connect handshake health |
| `SubscribeToShardEvent.Success` | AVG | Per-event delivery success |
| `SubscribeToShardEvent.Records` | SUM | Records delivered |
| `SubscribeToShardEvent.Bytes` | SUM | Bytes delivered |

## Alarms (3)

New methods on `KinesisAlarmFactory`:

- `addConsumerIteratorMaxAgeAlarm` — GT, `TreatMissingData.MISSING`, reuses existing `MaxIteratorAgeThreshold { maxAgeInMillis }`
- `addConsumerSubscribeToShardRateExceededAlarm` — GT, `NOT_BREACHING`, new `ConsumerRateExceededThreshold { maxRateExceeded }`
- `addConsumerSubscribeToShardSuccessAlarm` — LT, `NOT_BREACHING`, new `MinConsumerSubscribeToShardSuccessThreshold { minSuccessRate }`

## Facade & aspect wiring

- `MonitoringFacade.monitorKinesisDataStreamConsumer({ streamName, consumerName, ... })`
- `MonitoringAspect` auto-monitors `kinesis.CfnStreamConsumer` (parses `StreamName` from `streamArn` via `Arn.split`)
- Aspect enabled via new `kinesisDataStreamConsumer` prop on `MonitoringAspectProps`

## Dashboard layout

- **Row 1** (summary): MillisBehindLatest | Subscribe Success (both success metrics) | Rate Exceeded — quarter-width each
- **Row 2**: Records | Bytes — half-width each

## Testing

- New snapshot tests: `test/monitoring/aws-kinesis/KinesisDataStreamConsumerMonitoring.test.ts` (no-alarms + all-alarms → asserts 3 alarms created)
- Extended `test/facade/MonitoringAspect.test.ts` with a `DataStreamConsumer` case
- Full `yarn build` green: 80 suites / 386 tests / 276 snapshots, packaged for js/java/python/dotnet

## Design notes

- Separate construct (not extension of stream monitoring) because per-consumer dashboards shouldn't pollute stream dashboards and the concerns differ (stream health vs. consumer lag)
- Both `SubscribeToShard.Success` and `SubscribeToShardEvent.Success` metrics are exposed, but only the former has a built-in convenience alarm (lower noise). The latter is measurable but users can roll their own alarm as needed
- Based on reference implementation in ArMarsCdkConstructs and observed production patterns in AOSSBeholderOperationsCDK, AREventRoutingCoralCdk, ABDestinationServiceCDK